### PR TITLE
Support using software PWM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ ifneq ($(call optbool,$(WITH_WIRINGPI_STUB)),)
 override _CFLAGS += -DWITH_WIRINGPI_STUB
 else
 override _LDFLAGS += -lwiringPi
+ifneq ($(call optbool,$(WIRINGPI_SOFT_PWM)),)
+override _CFLAGS += -DWIRINGPI_SOFT_PWM
+override _LDFLAGS += -lpthread
+endif
 endif
 
 


### PR DESCRIPTION
Use `make WIRINGPI_SOFT_PWM=1` to build a software pwm version of kvmd-fan.
Note: PKGBUILD not updated.

Fixes [#738](https://github.com/pikvm/pikvm/issues/738)