### PR TITLE
Fix PWM frequencies and align with Intel/Noctua specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ vgcore.*
 *.pkg.tar.xz
 *.pkg.tar.zst
 *.tar.gz
+
+.vscode/
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CFLAGS ?= -O3
 LDFLAGS ?=
 
 _APP = kvmd-fan
-_CFLAGS = -MD -c -std=c17 -Wall -Wextra -D_GNU_SOURCE $(shell pkg-config --atleast-version=2 libgpiod 2> /dev/null && echo -DHAVE_GPIOD2)
+_CFLAGS = $(CFLAGS) -MD -c -std=c17 -Wall -Wextra -D_GNU_SOURCE $(shell pkg-config --atleast-version=2 libgpiod 2> /dev/null && echo -DHAVE_GPIOD2)
 _LDFLAGS = $(LDFLAGS) -lm -lpthread -liniparser -lmicrohttpd -lgpiod
 _SRCS = $(shell ls src/*.c)
 _BUILD = build

--- a/README.md
+++ b/README.md
@@ -4,3 +4,34 @@
 
 This repository contains the configuration and code of KVMD-FAN, a small fan controller daemon for PiKVM.
 If your request does not relate directly to this codebase, please send it to issues of the [PiKVM](https://github.com/pikvm/pikvm/issues) repository.
+
+# Configuration
+
+```ini
+; /etc/kvmd/fan.ini
+[main]
+pwm_pin = 12
+hall_pin = 6
+
+[speed]
+idle = 10
+low = 33
+
+[temp]
+low = 35
+
+[server]
+unix = /run/kvmd/fan.sock
+unix_rm = 1
+unix_mode = 666
+
+[logging]
+level = 1
+```
+
+Same with args (check out `kvmd-fan --help`):
+
+```bash
+# vim /etc/conf.d/kvmd-fan
+KVMD_FAN_ARGS="--verbose --pwm-pin 12 --hall-pin 6 --speed-idle 10 --speed-low 33 --temp-low 35 --unix /run/kvmd/fan.sock --unix-rm --unix-mode 666"
+```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ If your request does not relate directly to this codebase, please send it to iss
 ; /etc/kvmd/fan.ini
 [main]
 pwm_pin = 12
+; Default is 20% as per Intel spec, but most of the modern fans will do fine starting from 0 duty cycle
+pwm_min_duty = 0
 hall_pin = 6
 
 [speed]
@@ -33,5 +35,5 @@ Same with args (check out `kvmd-fan --help`):
 
 ```bash
 # vim /etc/conf.d/kvmd-fan
-KVMD_FAN_ARGS="--verbose --pwm-pin 12 --hall-pin 6 --speed-idle 10 --speed-low 33 --temp-low 35 --unix /run/kvmd/fan.sock --unix-rm --unix-mode 666"
+KVMD_FAN_ARGS="--verbose --pwm-pin 12 --pwm-min-duty 0 --hall-pin 6 --speed-idle 10 --speed-low 33 --temp-low 35 --unix /run/kvmd/fan.sock --unix-rm --unix-mode 666"
 ```

--- a/src/fan.c
+++ b/src/fan.c
@@ -117,10 +117,11 @@ fan_s *fan_init(unsigned pwm_pin, unsigned pwm_low, unsigned pwm_high, unsigned 
 			goto error;
 		}
 		int flags;
+		// It is safer to assume tacho signal requires to be pulled-up than leave the dangling wire
 		switch (hall_bias) {
 			case FAN_BIAS_PULL_DOWN: flags = GPIOD_LINE_REQUEST_FLAG_BIAS_PULL_DOWN; break;
-			case FAN_BIAS_PULL_UP: flags = GPIOD_LINE_REQUEST_FLAG_BIAS_PULL_UP; break;
-			default: flags = GPIOD_LINE_REQUEST_FLAG_BIAS_DISABLE;
+			case FAN_BIAS_DISABLED: flags = GPIOD_LINE_REQUEST_FLAG_BIAS_DISABLE; break;
+			default: flags = GPIOD_LINE_REQUEST_FLAG_BIAS_PULL_UP;
 		}
 		if (gpiod_line_request_falling_edge_events_flags(fan->line, "kvmd-fan::hall", flags) < 0) {
 			LOG_PERROR("fan.hall", "Can't request GPIO notification");

--- a/src/fan.c
+++ b/src/fan.c
@@ -146,11 +146,11 @@ void fan_destroy(fan_s *fan) {
 unsigned fan_set_speed_percent(fan_s *fan, float speed) {
 	unsigned pwm;
 	if (speed == 0) {
-		pwm = 0;
+		pwm = (int) fan->pwm_low;
 	} else if (speed == 100) {
-		pwm = 1024;
+		pwm = (int) fan->pwm_high;
 	} else {
-		pwm = roundf(remap(speed, 0, 100, fan->pwm_low, fan->pwm_high));
+		pwm = (int) roundf(remap(speed, 0, 100, fan->pwm_low, fan->pwm_high));
 	}
 #	ifndef WITH_WIRINGPI_STUB
 	if (fan->pwm_soft) {

--- a/src/fan.c
+++ b/src/fan.c
@@ -41,7 +41,8 @@ fan_s *fan_init(unsigned pwm_pin, unsigned pwm_low, unsigned pwm_high, unsigned 
 #	ifndef WITH_WIRINGPI_STUB
 	wiringPiSetupGpio();
 	if (pwm_soft) {
-		softPwmCreate(pwm_pin, 0, pwm_soft);
+		LOG_INFO("fan.pwm", "Using software PWM");
+		softPwmCreate(pwm_pin, 0, pwm_high);
 	} else {
 		pinMode(pwm_pin, PWM_OUTPUT);
 	}
@@ -154,7 +155,7 @@ unsigned fan_set_speed_percent(fan_s *fan, float speed) {
 	}
 #	ifndef WITH_WIRINGPI_STUB
 	if (fan->pwm_soft) {
-		softPwmWrite(fan->pwm_pin, pwm / 1024.0 * fan->pwm_soft);
+		softPwmWrite(fan->pwm_pin, pwm);
 	} else {
 		pwmWrite(fan->pwm_pin, pwm);
 	}

--- a/src/fan.c
+++ b/src/fan.c
@@ -58,7 +58,8 @@ fan_s *fan_init(unsigned pwm_pin, unsigned pwm_low, unsigned pwm_high, unsigned 
 		pwmSetClock(6);
 		// 19200000/6/25000 = 128
 		// 54000000/16/25000 = 135 - good enough value for both Pi3 and Pi4
-		pwmSetRange(135);
+		fan->pwm_high = 135;
+		pwmSetRange(fan->pwm_high);
 	}
 #	endif
 
@@ -80,8 +81,8 @@ fan_s *fan_init(unsigned pwm_pin, unsigned pwm_low, unsigned pwm_high, unsigned 
 		assert(!gpiod_line_settings_set_edge_detection(line_settings, GPIOD_LINE_EDGE_FALLING));
 		assert(!gpiod_line_settings_set_bias(line_settings,
 			hall_bias == FAN_BIAS_PULL_DOWN ? GPIOD_LINE_BIAS_PULL_DOWN
-			: hall_bias == FAN_BIAS_PULL_UP ? GPIOD_LINE_BIAS_PULL_UP
-			: GPIOD_LINE_BIAS_DISABLED
+			: hall_bias == FAN_BIAS_DISABLED ? GPIOD_LINE_BIAS_DISABLED
+			: GPIOD_LINE_BIAS_PULL_UP
 		));
 
 		struct gpiod_line_config *line_config;

--- a/src/fan.h
+++ b/src/fan.h
@@ -67,7 +67,7 @@ typedef struct {
 } fan_s;
 
 
-fan_s *fan_init(unsigned pwm_pin, unsigned pwm_low, unsigned pwm_high, unsigned pwm_soft, int hall_pin, fan_bias_e hall_bias);
+fan_s *fan_init(unsigned pwm_pin, float pwm_min_duty, unsigned pwm_soft, int hall_pin, fan_bias_e hall_bias);
 void fan_destroy(fan_s *fan);
 
 unsigned fan_set_speed_percent(fan_s *fan, float speed);

--- a/src/main.c
+++ b/src/main.c
@@ -129,7 +129,9 @@ static int _g_pwm_low = 0;
 static int _g_pwm_high = 1024;
 static int _g_pwm_soft = 0;
 static int _g_hall_pin = -1;
-static fan_bias_e _g_hall_bias = FAN_BIAS_DISABLED;
+// Most of the fans are using open collector output for tachometer output signal, so the default mode should use pull-up
+// See Noctua spec, for example: https://noctua.at/pub/media/wysiwyg/Noctua_PWM_specifications_white_paper.pdf
+static fan_bias_e _g_hall_bias = FAN_BIAS_PULL_UP;
 
 static float _g_temp_hyst = 3;
 static float _g_temp_low = 45;
@@ -311,7 +313,7 @@ static int _load_ini(const char *path) {
 	MATCH("main",		"pwm_high",		_g_pwm_high,		1, 1024,	0)
 	MATCH("main",		"pwm_soft",		_g_pwm_soft,		0, 1,		0)
 	MATCH("main",		"hall_pin",		_g_hall_pin,		-1, 256,	0)
-	MATCH("main",		"hall_bias",	_g_hall_bias,		FAN_BIAS_DISABLED, FAN_BIAS_PULL_UP, 0);
+	MATCH("main",		"hall_bias",	_g_hall_bias,		FAN_BIAS_DISABLED, FAN_BIAS_PULL_UP, FAN_BIAS_PULL_UP);
 	MATCH("main",		"interval",		_g_interval,		1, 10,		0)
 	MATCH("temp",		"hyst",			_g_temp_hyst,		1, 5,		0)
 	MATCH("temp",		"low",			_g_temp_low,		0, 85,		0)

--- a/src/main.c
+++ b/src/main.c
@@ -182,7 +182,7 @@ int main(int argc, char *argv[]) {
 			case _O_PWM_PIN:		OPT_NUMBER("--pwm-pin",			_g_pwm_pin,			0, 256);
 			case _O_PWM_LOW:		OPT_NUMBER("--pwm-low",			_g_pwm_low,			0, 1024);
 			case _O_PWM_HIGH:		OPT_NUMBER("--pwm-high",		_g_pwm_high,		1, 1024);
-			case _O_PWM_SOFT:		OPT_NUMBER("--pwm-soft",		_g_pwm_soft,		50, 100);
+			case _O_PWM_SOFT:		OPT_NUMBER("--pwm-soft",		_g_pwm_soft,		0, 1);
 			case _O_HALL_PIN:		OPT_NUMBER("--hall-pin",		_g_hall_pin,		-1, 256);
 			case _O_HALL_BIAS:		OPT_NUMBER("--hall-bias",		_g_hall_bias,		FAN_BIAS_DISABLED, FAN_BIAS_PULL_UP);
 
@@ -309,7 +309,7 @@ static int _load_ini(const char *path) {
 	MATCH("main",		"pwm_pin",		_g_pwm_pin,			0, 256,		0)
 	MATCH("main",		"pwm_low",		_g_pwm_low,			0, 1024,	0)
 	MATCH("main",		"pwm_high",		_g_pwm_high,		1, 1024,	0)
-	MATCH("main",		"pwm_soft",		_g_pwm_soft,		50, 100,	0)
+	MATCH("main",		"pwm_soft",		_g_pwm_soft,		0, 1,		0)
 	MATCH("main",		"hall_pin",		_g_hall_pin,		-1, 256,	0)
 	MATCH("main",		"hall_bias",	_g_hall_bias,		FAN_BIAS_DISABLED, FAN_BIAS_PULL_UP, 0);
 	MATCH("main",		"interval",		_g_interval,		1, 10,		0)

--- a/src/main.c
+++ b/src/main.c
@@ -56,6 +56,7 @@ enum _OPT_VALUES {
 	_O_PWM_SOFT,
 	_O_HALL_PIN,
 	_O_HALL_BIAS,
+	_O_PWM_MIN_DUTY,
 
 	_O_TEMP_HYST,
 	_O_TEMP_LOW,
@@ -80,8 +81,9 @@ enum _OPT_VALUES {
 static const char *const _SHORT_OPTS = "hvic:";
 static const struct option _LONG_OPTS[] = {
 	{"pwm-pin",			required_argument,	NULL,	_O_PWM_PIN},
-	{"pwm-low",			required_argument,	NULL,	_O_PWM_LOW},
-	{"pwm-high",		required_argument,	NULL,	_O_PWM_HIGH},
+	{"pwm-low",			required_argument,	NULL,	_O_PWM_LOW}, // deprecated, not used, left for compatibility
+	{"pwm-high",		required_argument,	NULL,	_O_PWM_HIGH}, // deprecated, not used, left for compatibility
+	{"pwm-min-duty",	required_argument,	NULL,	_O_PWM_MIN_DUTY},
 	{"pwm-soft",		required_argument,	NULL,	_O_PWM_SOFT},
 	{"hall-pin",		required_argument,	NULL,	_O_HALL_PIN},
 	{"hall-bias",		required_argument,	NULL,	_O_HALL_BIAS},
@@ -125,13 +127,16 @@ static fan_s *_g_fan = NULL;
 static server_s *_g_server = NULL;
 
 static int _g_pwm_pin = 12;
-static int _g_pwm_low = 0;
-static int _g_pwm_high = 1024;
+// Operation below 20% PWM duty-cycle is not officially supported in the Intel specification (undefined behavior).
+// However, most of the modern fans can be operated at below 20% and will stop at 0% duty-cycle.
+static float _g_pwm_min_duty = 20;
 static int _g_pwm_soft = 0;
 static int _g_hall_pin = -1;
 // Most of the fans are using open collector output for tachometer output signal, so the default mode should use pull-up
 // See Noctua spec, for example: https://noctua.at/pub/media/wysiwyg/Noctua_PWM_specifications_white_paper.pdf
 static fan_bias_e _g_hall_bias = FAN_BIAS_PULL_UP;
+static int _depr_pwm_low = 0;
+static int _depr_pwm_high = 1024;
 
 static float _g_temp_hyst = 3;
 static float _g_temp_low = 45;
@@ -182,9 +187,10 @@ int main(int argc, char *argv[]) {
 	for (int ch; (ch = getopt_long(argc, argv, _SHORT_OPTS, _LONG_OPTS, NULL)) >= 0;) {
 		switch (ch) {
 			case _O_PWM_PIN:		OPT_NUMBER("--pwm-pin",			_g_pwm_pin,			0, 256);
-			case _O_PWM_LOW:		OPT_NUMBER("--pwm-low",			_g_pwm_low,			0, 1024);
-			case _O_PWM_HIGH:		OPT_NUMBER("--pwm-high",		_g_pwm_high,		1, 1024);
-			case _O_PWM_SOFT:		OPT_NUMBER("--pwm-soft",		_g_pwm_soft,		0, 1);
+			case _O_PWM_LOW:		OPT_NUMBER("--pwm-low",			_depr_pwm_low,		0, 1024); // deprecated, not used
+			case _O_PWM_HIGH:		OPT_NUMBER("--pwm-high",		_depr_pwm_high,		1, 1024); // deprecated, not used
+			case _O_PWM_MIN_DUTY:	OPT_NUMBER("--pwm-min-duty",	_g_pwm_min_duty,	0, 50);
+			case _O_PWM_SOFT:		OPT_NUMBER("--pwm-soft",		_g_pwm_soft,		0, 1024);
 			case _O_HALL_PIN:		OPT_NUMBER("--hall-pin",		_g_hall_pin,		-1, 256);
 			case _O_HALL_BIAS:		OPT_NUMBER("--hall-bias",		_g_hall_bias,		FAN_BIAS_DISABLED, FAN_BIAS_PULL_UP);
 
@@ -221,11 +227,6 @@ int main(int argc, char *argv[]) {
 #	undef OPT_NUMBER
 #	undef OPT_NUMBER_BASE
 
-	if (_g_pwm_low >= _g_pwm_high) {
-		puts("Invalid PWM config, chould be: low < high");
-		goto error;
-	}
-
 	if (!(
 		0 <= _g_temp_hyst
 		&& _g_temp_hyst < _g_temp_low
@@ -249,7 +250,7 @@ int main(int argc, char *argv[]) {
 
 	_install_signal_handlers();
 
-	if ((_g_fan = fan_init(_g_pwm_pin, _g_pwm_low, _g_pwm_high, _g_pwm_soft, _g_hall_pin, _g_hall_bias)) == NULL) {
+	if ((_g_fan = fan_init(_g_pwm_pin, _g_pwm_min_duty, _g_pwm_soft, _g_hall_pin, _g_hall_bias)) == NULL) {
 		goto error;
 	}
 
@@ -309,11 +310,10 @@ static int _load_ini(const char *path) {
 		}
 
 	MATCH("main",		"pwm_pin",		_g_pwm_pin,			0, 256,		0)
-	MATCH("main",		"pwm_low",		_g_pwm_low,			0, 1024,	0)
-	MATCH("main",		"pwm_high",		_g_pwm_high,		1, 1024,	0)
-	MATCH("main",		"pwm_soft",		_g_pwm_soft,		0, 1,		0)
+	MATCH("main",		"pwm_min_duty",	_g_pwm_min_duty,	0, 50,		0)
+	MATCH("main",		"pwm_soft",		_g_pwm_soft,		0, 1024,	0)
 	MATCH("main",		"hall_pin",		_g_hall_pin,		-1, 256,	0)
-	MATCH("main",		"hall_bias",	_g_hall_bias,		FAN_BIAS_DISABLED, FAN_BIAS_PULL_UP, FAN_BIAS_PULL_UP);
+	MATCH("main",		"hall_bias",	_g_hall_bias,		FAN_BIAS_DISABLED, FAN_BIAS_PULL_UP, 0);
 	MATCH("main",		"interval",		_g_interval,		1, 10,		0)
 	MATCH("temp",		"hyst",			_g_temp_hyst,		1, 5,		0)
 	MATCH("temp",		"low",			_g_temp_low,		0, 85,		0)
@@ -485,9 +485,8 @@ static void _help(void) {
 	SAY("Hardware options:");
 	SAY("═════════════════");
 	SAY("    --pwm-pin <N>  ─── GPIO pin for PWM. Default: %d.\n", _g_pwm_pin);
-	SAY("    --pwm-low <N>  ─── PWM low level. Default: %d.\n", _g_pwm_low);
-	SAY("    --pwm-high <N>  ── PWM high level. Default: %d.\n", _g_pwm_high);
-	SAY("    --pwm-soft <N>  ── Use software PWM with specified range 0...N. Default: disabled.\n");
+	SAY("    --pwm-min-duty <N>  ─── Min duty cycle for PWM (0..50%%). Default: %.2f%%.\n", _g_pwm_min_duty);
+	SAY("    --pwm-soft <N>  ── Use software PWM with specified range 0...N. Default: 0 (disabled).\n");
 	SAY("    --hall-pin <N>  ── GPIO pin for the Hall sensor. Default: disabled.\n");
 	SAY("    --hall-bias <N>  ─ Hall pin bias: 0 = disabled, 1 = pull-down, 2 = pull-up. Default: %d.\n", _g_hall_bias);
 	SAY("Fan control options:");


### PR DESCRIPTION
Current implementation is a bit flawed in terms of PWM signal frequency. Measured ~300 kHz PWM signal when launched like this:

```bash
kvmd-fan --verbose --pwm-pin 12 --speed-const 50
```

Current implementation uses balanced PWM mode (aka MSEN=0, default one) instead of mark-and-sweep. Some fans will work fine with that, but that's not up to the specs.

[Noctua PWM fan specification](https://noctua.at/pub/media/wysiwyg/Noctua_PWM_specifications_white_paper.pdf) and the [Intel PWM fan specification](https://www.intel.com/content/dam/support/us/en/documents/intel-nuc/intel-4wire-pwm-fans-specs.pdf) both are recommending mark-space encoding with base frequencies ranging from 21kHz to 28kHz.

This PR addresses frequency issues and aligns produced PWM signal with those specs. Tested on rPi 4B (BCM2711) and rPi 3B+ (BCM2835).
Measured frequencies are now 25 kHz and 23.69 kHz respectively. Small discrepancy is due to different oscillator clocks (rPi4 uses 54 MHz base clock for PWM unlike 19.2 MHz on rPI3) and `wiringPi` lib does not allow to set PWM clock register (unlike `pigpio` lib, which [allows to choose clock source and uses PLLD by default](https://github.com/joan2937/pigpio/blob/c33738a320a3e28824af7807edafda440952c05d/pigpio.c#L7874)).

Also introducing `--pwm-min-duty` setting, which defaults to 20% (Intel spec recommends this value).
Some fans require it, some do not. For example, Noctua NF-A4x10 is spinning fine on lower end (<10%) while Elepeak PA4010S05HN2 fan needs at least around 18% minimal duty cycle on my tests.

As long as PWM upper bound is defined by PWM range now (which itself depends on the base clock) and lower bound is covered by `--pwm-min-duty` (set in percent of the upper bound), both `--pwm-low` and `--pwm-high` settings are no longer make sense and marked as deprecated (their values will be ignored if set).

Fixed minor issues in the software PWM settings along the way, but sw PWM is unreliable as it was, mostly kept intact. `--pwm-soft` now defines wider range upper bound with allowed values up to 1024. Lower range is defined by `--pwm-min-duty` (like in hw pwm).

Tacho pin readout default bias is changed to pull-up (most of the fans are using open collector output for tachometer pin).
