### PR TITLE
Set PWM mode and frequency for quieter fan

### DIFF
--- a/src/fan.c
+++ b/src/fan.c
@@ -44,6 +44,23 @@ fan_s *fan_init(unsigned pwm_pin, unsigned pwm_low, unsigned pwm_high, unsigned 
 		softPwmCreate(pwm_pin, 0, pwm_soft);
 	} else {
 		pinMode(pwm_pin, PWM_OUTPUT);
+		// Use mark-space mode to avoid "smoothing" the pulses, and adding noise
+		pwmSetMode(PWM_MODE_MS);
+		// Explicitly set the PWM Range, even though 1024 is the default
+		// match Range with value of "--pwm-high=" in /etc/conf.d/kvmd-fan
+		pwmSetRange( 1024 );
+		// Set the PWM clock divisor to get a PWM frequency as close to 25KHz as possible.
+		// 25KHz is the industry standard for small fans. 
+		// https://noctua.at/pub/media/wysiwyg/Noctua_PWM_specifications_white_paper.pdf
+
+		// The passed clock divisor for a RPi-4b is converted by wiringPi code to account for 
+		// the different oscillator frequencies in the 4b v.s. the 3b families (54MHz v.s. 19.2MHz).
+		//     cat /sys/kernel/debug/clk/osc/clk_rate
+		// The conversion is done using 'C' integer division, and all fractional remainders are lost.
+		// For RPi-4b, munged_divisor = 540*divisor/192. For clock==1, munged_divisor==2.
+		// 4b_pwm_freq = osc_freq/munged_divisor/Range = 54MHz/2/1024 = 26.367KHz - verified on 'scope
+		// 3b_pwm_freq = osc_freq/munged_divisor/Range = 19.2MHz/1/1024 = 18.750KHz - a little slow, but ok
+		pwmSetClock( 1 );
 	}
 #	endif
 

--- a/src/fan.c
+++ b/src/fan.c
@@ -59,7 +59,7 @@ fan_s *fan_init(unsigned pwm_pin, unsigned pwm_low, unsigned pwm_high, unsigned 
 		// The conversion is done using 'C' integer division, and all fractional remainders are lost.
 		// For RPi-4b, munged_divisor = 540*divisor/192. For clock==1, munged_divisor==2.
 		// 4b_pwm_freq = osc_freq/munged_divisor/Range = 54MHz/2/1024 = 26.367KHz - verified on 'scope
-		// 3b_pwm_freq = osc_freq/munged_divisor/Range = 19.2MHz/1/1024 = 18.750KHz - a little slow, but ok
+		// 3b_pwm_freq = osc_freq/divisor/Range = 19.2MHz/1/1024 = 18.750KHz - a little slow, but ok
 		pwmSetClock( 1 );
 	}
 #	endif


### PR DESCRIPTION
Using an oscilloscope and my sensitive hearing ;), I achieved much lower noise and slower minimum speed, by setting the PWM mode and frequency to "Mark-Space" and 25KHz respectively.  This is with 30mm & 40mm fans mounted on a RPi-4b Hat.

The wiringPi library defaults to "Balanced Mode", and a resulting high frequency signal at the PWM controller input.  By changing the frequency close to the more standard 25KHz, and using a fixed square-wave, the resulting noise artifacts are considerably reduced.  I am also able to achieve very low minimum fan rotation speeds under these conditions.

Note, this should be a backwards compatible change with any existing configuration in /etc/conf.d/kvmd-fan, as the default 1024 Range is not changed here.  Any user that has specified a different value for --pwm-high, was not changing the actual signal.

I'm using this - https://www.tindie.com/products/jeremycook/ez-fan2-tiny-raspberry-pi-fan-controller/
as my controller interface between the RPi GPIO PWM signal, and the two-wire fan.

I'm running kvmd-fan on a PiKVM clone (Geekworm PiKVM-A3), but I believe this change would be applicable to any small fan PWM controller.